### PR TITLE
Run codeQL on PRs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,7 @@ name: "Code scanning - action"
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 4 * * 0'
 


### PR DESCRIPTION
Please accept this so that I can keep testing opening PRs on a repo I do not have write access to.

The next PR will try to introduce an alert and see how the annotation is shown.